### PR TITLE
Update "Match|If|Function statement(s)" -> "Match|If|Function expressions(s)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ In order to use these optmized functions, ppx\_let provides the `let%mapn`
 syntax, which picks the right `map{n}` function to call based on the amount of
 applicatives bound by the syntax.
 
-### Match statements
+### Match expressions
 
-We found that this form was quite useful for match statements as well. So for
+We found that this form was quite useful for match expressions as well. So for
 convenience ppx\_let also accepts `%bind` and `%map` on the `match` keyword.
 Morally `match%bind expr with cases` is seen as `let%bind x = expr in match x
 with cases`.
 
-### If statements
+### If expressions
 
 As a further convenience, ppx\_let accepts `%bind` and `%map` on the `if`
 keyword. The expression `if%bind expr1 then expr2 else expr3` is morally
 equivalent to `let%bind p = expr1 in if p then expr2 else expr3`.
 
-### Function statements
+### Function expressions
 
 We accept `function%bind` and `function%map` too.
 


### PR DESCRIPTION
First of all... sorry for this level of pedantry. I know this is a minor pull request and it may not be valid. I'm grateful you are considering it. If it is incorrect, please disregard.

The README identifies the terms "Match", "If", and "Function" as `statements`. These language constructs return values and therefore I believe they are technically `expressions`.

Even the text in the body of the `### If Statements` heading calls "If" an expression:

"
... The **expression** `if%bind expr1 then expr2 else expr3` is morally equivalent to `let%bind p = expr1 in if p then expr2 else expr3`. 
"

Again, thanks for considering this pull request.