### PR TITLE
Changes for Ppxlib 5.2 AST

### DIFF
--- a/expander/ppx_let_expander.ml
+++ b/expander/ppx_let_expander.ml
@@ -395,7 +395,7 @@ let expand_while
 
 let expand_function ~loc ~return_value_in_exclave cases =
   match return_value_in_exclave with
-  | false -> pexp_function ~loc cases
+  | false -> pexp_function_cases ~loc cases
   | true ->
     let var = gen_symbol ~prefix:"__let_syntax" () in
     pexp_match ~loc (evar ~loc var) cases


### PR DESCRIPTION
Change for [ppxlib.0.36.0](https://github.com/ocaml/opam-repository/pull/27478) which now uses the 5.2 AST i.e. incorporating the syntactic arity changes for the parsetree.